### PR TITLE
Another mf pull request (Fix login length)

### DIFF
--- a/views/pages/login.ejs
+++ b/views/pages/login.ejs
@@ -25,7 +25,7 @@
                     </div>
                 </div>
                 <div style="overflow: hidden; margin-top: 24px; align-content: stretch; flex-direction: column; display: flex; flex-shrink: 0; align-items: stretch; align-self: auto; position: relative; flex-grow: 0;">
-                    <input type="text" name="username" placeholder="Username#9999" autocomplete="username" pattern="^[a-zA-Z0-9.]+#\d{4}$" minlength="3" maxlength="30" oninvalid="this.setCustomValidity('Invalid characters! Usernames contain letters, numbers, and periods, followed by a discriminator \(#0001\).')" oninput="this.setCustomValidity('')" required />
+                    <input type="text" name="username" placeholder="Username#9999" autocomplete="username" pattern="^[a-zA-Z0-9.]+#\d{4}$" minlength="8" maxlength="35" oninvalid="this.setCustomValidity('Invalid characters! Usernames contain letters, numbers, and periods, followed by a discriminator \(#0001\).')" oninput="this.setCustomValidity('')" required />
                     <input type="password" name="password" placeholder="Password" autocomplete="current-password" required />
                     <button type="submit">Login</button>
                     <div style="margin: 10px 40px 18px;">


### PR DESCRIPTION
So lets say you register with the username ... which is 3 characters (the minimum). The discriminator adds 5 characters so you have 8 as the minimum. Now lets say that you have the username Xx69420.DrauliscBreaker42069xX which is 30 characters (the maximum). The discriminator adds 5 characters so you have 35 as the minimum to be able to log into your account. Therefore the correct range for login is 8-35 to let all the people who registered with 3-30 to log in.